### PR TITLE
Implement filterPath & filteringPathRegEx

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,27 @@ As the `reply` and `replyWithFile` methods return the current hockServer, you ca
 ## Matching requests
 
 When a request comes in, hock iterates through the queue in a First-in-first-out approach, so long as the request matches. The criteria for matching is based on the method and the url, and additionally the request body if the request is a `PUT` or `POST`. If you specify request headers, they will also be matched against before sending the response.
+
+## Path filtering
+
+You can filter paths using regex or a custom function, this is useful for things like timestamps that get appended to urls from clients.
+
+```Javascript
+
+    hockServer
+        .filteringPathRegEx(/timestamp=[^&]*/g, 'timestamp=123')
+        .get('/url?timestamp=123')
+        .reply(200, 'Hi!');
+
+```
+
+```Javascript
+
+    hockServer
+        .filteringPath(function (p) {
+            return '/url?timestamp=XXX';
+        })
+        .get('/url?timestamp=XXX')
+        .reply(200, 'Hi!');
+
+```

--- a/lib/hock.js
+++ b/lib/hock.js
@@ -117,6 +117,22 @@ Hock.prototype.filteringRequestBodyRegEx = function (source, replace) {
   return this;
 };
 
+Hock.prototype.filteringPath = function (filter) {
+  this._pathFilter = filter;
+  return this;
+};
+
+Hock.prototype.filteringPathRegEx = function (source, replace) {
+  this._pathFilter = function (path) {
+    if (path) {
+      path = path.replace(source, replace);
+    }
+    return path;
+  };
+
+  return this;
+};
+
 Hock.prototype.clearBodyFilter = function () {
   delete this._requestFilter;
   return this;

--- a/lib/request.js
+++ b/lib/request.js
@@ -47,6 +47,10 @@ Request.prototype.replyWithFile = function (statusCode, filePath, headers) {
 Request.prototype.isMatch = function(request) {
   var self = this;
 
+  if (this._parent._pathFilter) {
+    request.url = this._parent._pathFilter(request.url);
+  }
+
   if (request.method === 'GET' || request.method === 'DELETE') {
     return this.method === request.method && request.url === this.url && checkHeaders();
   }


### PR DESCRIPTION
This is useful if one is mocking for a client which appends
timestamps to the request path as GET parameter

Example: the search command of npm which is not adding a timestamp, but a startkey

```
/-/all/since?stale=update_after&startkey=1387902878592
```

https://github.com/robertkowalski/npm-registry-mock/issues/5
