### PR TITLE
Remove everything related to HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,32 +10,23 @@ Hock is designed as a fully functioning HTTP service. You enqueue requests and r
 
 ```Javascript
 
-    var hock = require('hock'),
+    var http = require('http'),
+        hock = require('hock'),
         request = require('request');
 
-    hock.createHock(function(err, hockServer) {
-        var port = hockServer.address().port;
+    var mock = hock.createHock();
+    mock
+        .get('/some/url')
+        .reply(200, 'Hello!');
 
-        hockServer
-            .get('/some/url')
-            .reply(200, 'Hello!');
-
-        request('http://localhost:' + port + '/some/url', function(err, res, body) {
+    var server = http.createServer(mock.handler);
+    server.listen(1337, function () {
+        request('http://localhost:' + 1337 + '/some/url', function(err, res, body) {
            console.log(body);
         });
     });
 
 ```
-
-A port can be optionally specified when creating the server:
-
-```Javascript
-    hock.createHock(12345, function(err, hockServer) {
-        ....
-    });
-```
-
-Unlike Nock, you create a `Hock` server with a callback based factory method. Behind the scenes, this spins up the new HTTP service, and begins listening to requests.
 
 ## HTTP Methods
 

--- a/lib/hock.js
+++ b/lib/hock.js
@@ -8,25 +8,16 @@ var http = require('http'),
  * of the underlying webserver, and enqueing all of the requests.
  *
  * @param {object}      [options]       options for your Hock server
- * @param {Number}      [options]       an optional port for your Hock server
- * @param {Number}      [options.port]  port number for your Hock server
  * @param {boolean}     [options.throwOnUnmatched]  Tell Hock to throw if
  *    receiving a request without a match (Default=true)
  *
  * @type {Function}
  */
 var Hock = module.exports = function (options) {
-  if (typeof options === 'number') {
-    this.port = options;
-    options = {};
-  }
-  else if (typeof options === 'object' && options.port) {
-    this.port = options.port;
-  }
-
+  options = options || {};
   this._throwOnUnmatched = (typeof options.throwOnUnmatched === 'boolean' ? options.throwOnUnmatched : true);
   this._assertions = [];
-  this._started = false;
+  this.handler = Hock.prototype.handler.bind(this);
 };
 
 /**
@@ -82,51 +73,6 @@ Hock.prototype.done = function (cb) {
 
   return cb(err);
 
-};
-
-/**
- * Hock.close
- *
- * @description stop listening and shutdown the Hock server
- *
- * @param callback
- */
-Hock.prototype.close = function (callback) {
-  this._server.close(callback);
-};
-
-/**
- * Hock.address
- *
- * @description retrieve the address for the hock server
-
- * @returns {*}
- */
-Hock.prototype.address = function() {
-  return this._server.address();
-};
-
-/**
- * Hock._initialize
- *
- * @description The internal helper function to start the Hock server
- *
- * @param {Function}    callback    This is fired when the server is listening
- * @private
- */
-Hock.prototype._initialize = function (callback) {
-  var self = this;
-
-  if (self._started) {
-    callback(new Error('Server is already listening'));
-    return;
-  }
-
-  self._server = http.createServer(this._handleRequest());
-  self._server.listen(self.port, function () {
-    self._started = true;
-    callback(null, self);
-  });
 };
 
 /**
@@ -322,53 +268,51 @@ Hock.prototype.defaultReplyHeaders = function (headers) {
 };
 
 /**
- * Hock._handleReqeust
+ * Hock.handler
  *
- * @description internal helper function for handling requests
+ * @description Handle incoming requests
  *
  * @returns {Function}
  * @private
  */
-Hock.prototype._handleRequest = function () {
+Hock.prototype.handler = function (req, res) {
   var self = this;
 
-  return function (req, res) {
-    var matchIndex = null;
+  var matchIndex = null;
 
-    req.body = '';
+  req.body = '';
 
-    req.on('data', function (data) {
-      req.body += data.toString();
-    });
+  req.on('data', function (data) {
+    req.body += data.toString();
+  });
 
-    req.on('end', function () {
+  req.on('end', function () {
 
-      for (var i = 0; i < self._assertions.length; i++) {
-        if (self._assertions[i].isMatch(req)) {
-          matchIndex = i;
-          break;
-        }
+    for (var i = 0; i < self._assertions.length; i++) {
+      if (self._assertions[i].isMatch(req)) {
+        matchIndex = i;
+        break;
+      }
+    }
+
+    if (matchIndex === null) {
+      if (self._throwOnUnmatched) {
+        throw new Error('No Match For: ' + req.method + ' ' + req.url);
       }
 
-      if (matchIndex === null) {
-        if (self._throwOnUnmatched) {
-          throw new Error('No Match For: ' + req.method + ' ' + req.url);
-        }
-
-        console.error('No Match For: ' + req.method + ' ' + req.url);
-        if (req.method === 'PUT' || req.method === 'POST') {
-          console.error(req.body);
-        }
-        res.writeHead(500, { 'Content-Type': 'text/plain' });
-        res.end('No Matching Response!\n');
+      console.error('No Match For: ' + req.method + ' ' + req.url);
+      if (req.method === 'PUT' || req.method === 'POST') {
+        console.error(req.body);
       }
-      else {
-        if (self._assertions[matchIndex].sendResponse(res)) {
-          self._assertions.splice(matchIndex, 1)[0];
-        }
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('No Matching Response!\n');
+    }
+    else {
+      if (self._assertions[matchIndex].sendResponse(res)) {
+        self._assertions.splice(matchIndex, 1)[0];
       }
-    });
-  }
+    }
+  });
 };
 
 /**
@@ -385,14 +329,13 @@ Hock.prototype._handleRequest = function () {
  *
  * @returns {Hock}
  */
-var createHock = function(options, callback) {
+var createHock = function(options) {
   // options is optional
   if (typeof options === 'function') {
     callback = options;
     options = {};
   }
   var hock = new Hock(options);
-  hock._initialize(callback);
   return hock;
 };
 

--- a/lib/hock.js
+++ b/lib/hock.js
@@ -64,7 +64,7 @@ Hock.prototype.done = function (cb) {
   }
 
   if (!err) {
-    return cb && cb()
+    return cb && cb();
   }
 
   if (!cb) {

--- a/test/many-test.js
+++ b/test/many-test.js
@@ -1,4 +1,5 @@
-var should = require('should'),
+var http = require('http'),
+  should = require('should'),
   request = require('request'),
   hock = require('../');
 
@@ -7,14 +8,15 @@ var PORT = 5678;
 describe('Hock Multiple Request Tests', function () {
 
   var server;
+  var httpServer;
 
   describe("With minimum requests", function () {
     beforeEach(function (done) {
-      hock.createHock(function (err, hockServer) {
+      server = hock.createHock();
+      httpServer = http.createServer(server.handler).listen(PORT, function(err) {
         should.not.exist(err);
-        should.exist(hockServer);
+        should.exist(server);
 
-        server = hockServer;
         done();
       });
     });
@@ -25,7 +27,7 @@ describe('Hock Multiple Request Tests', function () {
         .once()
         .reply(200, { 'hock': 'ok' });
 
-      request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+      request('http://localhost:' + PORT + '/url', function (err, res, body) {
         should.not.exist(err);
         should.exist(res);
         res.statusCode.should.equal(200);
@@ -41,7 +43,7 @@ describe('Hock Multiple Request Tests', function () {
         .min(2)
         .reply(200, { 'hock': 'ok' });
 
-      request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+      request('http://localhost:' + PORT + '/url', function (err, res, body) {
         should.not.exist(err);
         should.exist(res);
         res.statusCode.should.equal(200);
@@ -59,13 +61,13 @@ describe('Hock Multiple Request Tests', function () {
         .min(2)
         .reply(200, { 'hock': 'ok' });
 
-      request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+      request('http://localhost:' + PORT + '/url', function (err, res, body) {
         should.not.exist(err);
         should.exist(res);
         res.statusCode.should.equal(200);
         JSON.parse(body).should.eql({ 'hock': 'ok' });
 
-        request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+        request('http://localhost:' + PORT + '/url', function (err, res, body) {
           should.not.exist(err);
           should.exist(res);
           res.statusCode.should.equal(200);
@@ -83,7 +85,7 @@ describe('Hock Multiple Request Tests', function () {
         .max(2)
         .reply(200, { 'hock': 'ok' });
 
-      request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+      request('http://localhost:' + PORT + '/url', function (err, res, body) {
         should.not.exist(err);
         should.exist(res);
         res.statusCode.should.equal(200);
@@ -100,13 +102,13 @@ describe('Hock Multiple Request Tests', function () {
         .max(2)
         .reply(200, { 'hock': 'ok' });
 
-      request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+      request('http://localhost:' + PORT + '/url', function (err, res, body) {
         should.not.exist(err);
         should.exist(res);
         res.statusCode.should.equal(200);
         JSON.parse(body).should.eql({ 'hock': 'ok' });
 
-        request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+        request('http://localhost:' + PORT + '/url', function (err, res, body) {
           should.not.exist(err);
           should.exist(res);
           res.statusCode.should.equal(200);
@@ -125,13 +127,13 @@ describe('Hock Multiple Request Tests', function () {
         .max(3)
         .reply(200, { 'hock': 'ok' });
 
-      request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+      request('http://localhost:' + PORT + '/url', function (err, res, body) {
         should.not.exist(err);
         should.exist(res);
         res.statusCode.should.equal(200);
         JSON.parse(body).should.eql({ 'hock': 'ok' });
 
-        request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+        request('http://localhost:' + PORT + '/url', function (err, res, body) {
           should.not.exist(err);
           should.exist(res);
           res.statusCode.should.equal(200);
@@ -150,13 +152,13 @@ describe('Hock Multiple Request Tests', function () {
         .max(Infinity)
         .reply(200, { 'hock': 'ok' });
 
-      request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+      request('http://localhost:' + PORT + '/url', function (err, res, body) {
         should.not.exist(err);
         should.exist(res);
         res.statusCode.should.equal(200);
         JSON.parse(body).should.eql({ 'hock': 'ok' });
 
-        request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+        request('http://localhost:' + PORT + '/url', function (err, res, body) {
           should.not.exist(err);
           should.exist(res);
           res.statusCode.should.equal(200);
@@ -178,19 +180,19 @@ describe('Hock Multiple Request Tests', function () {
         .once()
         .reply(200, { 'hock': 'ok' });
 
-      request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+      request('http://localhost:' + PORT + '/url', function (err, res, body) {
         should.not.exist(err);
         should.exist(res);
         res.statusCode.should.equal(200);
         JSON.parse(body).should.eql({ 'hock': 'ok' });
 
-        request('http://localhost:' + server.address().port + '/asdf', function (err, res, body) {
+        request('http://localhost:' + PORT + '/asdf', function (err, res, body) {
           should.not.exist(err);
           should.exist(res);
           res.statusCode.should.equal(200);
           JSON.parse(body).should.eql({ 'hock': 'ok' });
 
-          request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+          request('http://localhost:' + PORT + '/url', function (err, res, body) {
             should.not.exist(err);
             should.exist(res);
             res.statusCode.should.equal(200);
@@ -209,7 +211,7 @@ describe('Hock Multiple Request Tests', function () {
           .get('/url')
           .replyWithFile(200, process.cwd() + '/test/data/hello.txt');
 
-        request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+        request('http://localhost:' + PORT + '/url', function (err, res, body) {
           should.not.exist(err);
           should.exist(res);
           res.statusCode.should.equal(200);
@@ -227,13 +229,13 @@ describe('Hock Multiple Request Tests', function () {
           .twice()
           .replyWithFile(200, process.cwd() + '/test/data/hello.txt');
 
-        request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+        request('http://localhost:' + PORT + '/url', function (err, res, body) {
           should.not.exist(err);
           should.exist(res);
           res.statusCode.should.equal(200);
           body.should.equal('this\nis\nmy\nsample\n');
 
-          request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+          request('http://localhost:' + PORT + '/url', function (err, res, body) {
             should.not.exist(err);
             should.exist(res);
             res.statusCode.should.equal(200);
@@ -267,19 +269,19 @@ describe('Hock Multiple Request Tests', function () {
           .many()
           .reply(200, { 'hock': 'ok' })
 
-        request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+        request('http://localhost:' + PORT + '/url', function (err, res, body) {
           should.not.exist(err);
           should.exist(res);
           res.statusCode.should.equal(200);
           JSON.parse(body).should.eql({ 'hock': 'ok' });
 
-          request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+          request('http://localhost:' + PORT + '/url', function (err, res, body) {
             should.not.exist(err);
             should.exist(res);
             res.statusCode.should.equal(200);
             JSON.parse(body).should.eql({ 'hock': 'ok' });
 
-            request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+            request('http://localhost:' + PORT + '/url', function (err, res, body) {
               should.not.exist(err);
               should.exist(res);
               res.statusCode.should.equal(200);
@@ -310,19 +312,19 @@ describe('Hock Multiple Request Tests', function () {
           .any()
           .reply(200, { 'hock': 'ok' });
 
-        request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+        request('http://localhost:' + PORT + '/url', function (err, res, body) {
           should.not.exist(err);
           should.exist(res);
           res.statusCode.should.equal(200);
           JSON.parse(body).should.eql({ 'hock': 'ok' });
 
-          request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+          request('http://localhost:' + PORT + '/url', function (err, res, body) {
             should.not.exist(err);
             should.exist(res);
             res.statusCode.should.equal(200);
             JSON.parse(body).should.eql({ 'hock': 'ok' });
 
-            request('http://localhost:' + server.address().port + '/url', function (err, res, body) {
+            request('http://localhost:' + PORT + '/url', function (err, res, body) {
               should.not.exist(err);
               should.exist(res);
               res.statusCode.should.equal(200);
@@ -337,7 +339,7 @@ describe('Hock Multiple Request Tests', function () {
     });
 
     afterEach(function (done) {
-      server.close(done);
+      httpServer.close(done);
     });
   });
 });

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -1,4 +1,5 @@
-var should = require('should'),
+var http = require('http'),
+    should = require('should'),
     request = require('request'),
     hock = require('../');
 
@@ -7,14 +8,15 @@ var PORT = 5678;
 describe('Hock HTTP Tests', function() {
 
   var server;
+  var httpServer;
 
   describe("with available ports", function() {
     before(function(done) {
-      hock.createHock(function(err, hockServer) {
+      server = hock.createHock();
+      httpServer = http.createServer(server.handler).listen(PORT, function(err) {
         should.not.exist(err);
-        should.exist(hockServer);
+        should.exist(server);
 
-        server = hockServer;
         done();
       });
     });
@@ -24,7 +26,7 @@ describe('Hock HTTP Tests', function() {
         .get('/url')
         .reply(200, { 'hock': 'ok' });
 
-      request('http://localhost:' + server.address().port + '/url', function(err, res, body) {
+      request('http://localhost:' + PORT + '/url', function(err, res, body) {
         should.not.exist(err);
         should.exist(res);
         res.statusCode.should.equal(200);
@@ -40,7 +42,7 @@ describe('Hock HTTP Tests', function() {
         .reply(201, { 'hock': 'created' });
 
       request({
-        uri: 'http://localhost:' + server.address().port + '/post',
+        uri: 'http://localhost:' + PORT + '/post',
         method: 'POST',
         json: {
           'hock': 'post'
@@ -60,7 +62,7 @@ describe('Hock HTTP Tests', function() {
         .reply(204, { 'hock': 'updated' });
 
       request({
-        uri: 'http://localhost:' +server.address().port+ '/put',
+        uri: 'http://localhost:' +PORT+ '/put',
         method: 'PUT',
         json: {
           'hock': 'put'
@@ -80,7 +82,7 @@ describe('Hock HTTP Tests', function() {
         .reply(202, { 'hock': 'deleted' });
 
       request({
-        uri: 'http://localhost:' +server.address().port+ '/delete',
+        uri: 'http://localhost:' +PORT+ '/delete',
         method: 'DELETE'
       }, function (err, res, body) {
         should.not.exist(err);
@@ -98,7 +100,7 @@ describe('Hock HTTP Tests', function() {
         .reply(200, '', { 'Content-Type': 'plain/text' });
 
       request({
-        uri: 'http://localhost:' +server.address().port+ '/head',
+        uri: 'http://localhost:' +PORT+ '/head',
         method: 'HEAD'
       }, function (err, res, body) {
         should.not.exist(err);
@@ -132,44 +134,15 @@ describe('Hock HTTP Tests', function() {
     });
   });
 
-  describe("with hard coded ports", function() {
-    before(function(done) {
-      hock.createHock(PORT, function(err, hockServer) {
-        should.not.exist(err);
-        should.exist(hockServer);
-
-        server = hockServer;
-        done();
-      });
-    });
-
-    it('should correctly respond to an HTTP GET request', function(done) {
-      server
-        .get('/url')
-        .reply(200, { 'hock': 'ok' });
-
-      request('http://localhost:' + PORT + '/url', function(err, res, body) {
-        should.not.exist(err);
-        should.exist(res);
-        res.statusCode.should.equal(200);
-        JSON.parse(body).should.eql({ 'hock': 'ok' });
-        done();
-
-      });
-    });
-
-    after(function(done) {
-      server.close(done);
-    });
-  });
-
   describe("dynamic path replacing / filtering", function() {
     before(function(done) {
-      hock.createHock(PORT, function(err, hockServer) {
-        should.not.exist(err);
-        should.exist(hockServer);
+      httpServer.close();
 
-        server = hockServer;
+      server = hock.createHock();
+      httpServer = http.createServer(server.handler).listen(PORT, function(err) {
+        should.not.exist(err);
+        should.exist(server);
+
         done();
       });
     });
@@ -210,7 +183,7 @@ describe('Hock HTTP Tests', function() {
     });
 
     after(function(done) {
-      server.close(done);
+      httpServer.close(done);
     });
   });
 });


### PR DESCRIPTION
Users are expected to create their own HTTP(S) server and set its
request listener to `hock.handler`.

Fixes #14.

Holy crap, this removes tons of code, while adding none on implementors' side.