### PR TITLE
Allow for any query string order

### DIFF
--- a/lib/hock.js
+++ b/lib/hock.js
@@ -4,7 +4,8 @@ var qs = require('querystring'),
     url_ = require('url'),
     http = require('http'),
     Request = require('./request'),
-    deepEqual = require('deep-equal');
+    deepEqual = require('deep-equal'),
+    urlEqual = require('url-equal');
 
 /**
  * Hock class
@@ -65,16 +66,9 @@ Hock.prototype.hasRoute = function (method, url, body, headers) {
     headers = {};
   }
 
-  const parsedUrl = url_.parse(url),
-        parsedQs = qs.parse(parsedUrl);
-
   var found = this._assertions.filter(function(request) {
-    const parsedRequestUrl = url_.parse(request.url),
-          parsedRequestQs = qs.decode(parsedRequestUrl);
-
     return request.method === method
-          && parsedRequestUrl.pathname === parsedUrl.pathname
-          && deepEqual(parsedRequestQs, parsedQs)
+          && urlEqual(url, request.url)
           && request.body === body
           && deepEqual(request.headers, headers);
   })

--- a/lib/hock.js
+++ b/lib/hock.js
@@ -1,4 +1,8 @@
-var http = require('http'),
+'use strict';
+
+var qs = require('querystring'),
+    url_ = require('url'),
+    http = require('http'),
     Request = require('./request'),
     deepEqual = require('deep-equal');
 
@@ -61,9 +65,16 @@ Hock.prototype.hasRoute = function (method, url, body, headers) {
     headers = {};
   }
 
+  const parsedUrl = url_.parse(url),
+        parsedQs = qs.parse(parsedUrl);
+
   var found = this._assertions.filter(function(request) {
+    const parsedRequestUrl = url_.parse(request.url),
+          parsedRequestQs = qs.decode(parsedRequestUrl);
+
     return request.method === method
-          && request.url === url
+          && parsedRequestUrl.pathname === parsedUrl.pathname
+          && deepEqual(parsedRequestQs, parsedQs)
           && request.body === body
           && deepEqual(request.headers, headers);
   })

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,5 +1,11 @@
+'use strict';
+
 var fs = require('fs'),
-    Stream = require('stream');
+    qs = require('querystring'),
+    url_ = require('url'),
+    Stream = require('stream'),
+    urlEqual = require('url-equal'),
+    deepEqual = require('deep-equal');
 
 // From Nock
 function isStream(obj) {
@@ -201,7 +207,8 @@ Request.prototype.isMatch = function(request) {
   }
 
   if (request.method === 'GET' || request.method === 'DELETE') {
-    return this.method === request.method && request.url === this.url && checkHeaders();
+    return this.method === request.method && urlEqual(this.url, request.url) &&
+      checkHeaders();
   }
   else {
     var body = request.body;
@@ -209,7 +216,7 @@ Request.prototype.isMatch = function(request) {
       body = this._requestFilter(request.body);
     }
 
-    return this.method === request.method && this.url === request.url &&
+    return this.method === request.method && urlEqual(this.url, request.url) &&
       this.body === body && checkHeaders();
 
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "deep-equal": "0.2.1",
-    "url-equal": "~0.1.1"
+    "url-equal": "0.1.2-1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "node": ">=0.8.x"
   },
   "dependencies": {
-    "deep-equal": "0.2.1"
+    "deep-equal": "0.2.1",
+    "url-equal": "~0.1.1"
   }
 }

--- a/test/request-test.js
+++ b/test/request-test.js
@@ -31,5 +31,17 @@ describe('Request unit tests', function () {
         headers: {}
       }).should.equal(false);
     });
+
+    it('should accept any order of query strings', function () {
+      var request = new Request(new Object(), {
+        method: 'GET',
+        url: '/?foo=bar&bar=foo'
+      });
+
+      request.isMatch({
+        method: 'GET',
+        url: '/?bar=foo&foo=bar'
+      }).should.equal(true);
+    });
   });
 });

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -281,6 +281,15 @@ describe('Hock HTTP Tests', function() {
       done();
     });
 
+    it('matches different order of querystring parameters', function(done) {
+      hockInstance
+        .get('/url?user=foo&pass=bar')
+        .reply(200, { 'hock': 'ok' });
+
+      hockInstance.hasRoute('GET', '/url?pass=bar&user=foo').should.equal(true);
+      done();
+    });
+
     after(function(done) {
       httpServer.close(done);
     });


### PR DESCRIPTION
Fix `/?foo=bar&bar=foo` not matching `/?bar=foo&foo=bar`.

Order of query string parameters shouldn't be relevant to any
well-written application.
