### PR TITLE
Enables CORS, resolves mmalecki/hock#30 and adds a clearRoutes method

### DIFF
--- a/lib/hock.js
+++ b/lib/hock.js
@@ -383,7 +383,7 @@ Hock.prototype.handler = function (req, res) {
 
     if (matchIndex === null) {
       if (self._throwOnUnmatched) {
-        throw new Error('No Match For: ' + req.method + ' ' + req.url);
+        throw new Error('No Match For: ' + req.method + ' ' + req.url + ' with body ' + req.body);
       }
 
       console.error('No Match For: ' + req.method + ' ' + req.url);

--- a/lib/hock.js
+++ b/lib/hock.js
@@ -2,6 +2,14 @@ var http = require('http'),
     Request = require('./request'),
     deepEqual = require('deep-equal');
 
+var ALL_HEADERS = ['accept-charset', 'accept-encoding',
+    'access-control-request-headers', 'access-control-request-method',
+    'connection', 'content-length', 'cookie', 'cookie2', 'date',
+    'dnt', 'expect', 'host', 'keep-alive', 'origin', 'referer',
+    'te', 'trailer', 'transfer-encoding', 'upgrade', 'via'].join(',');
+var ALL_METHODS = ['GET', 'POST', 'HEAD', 'COPY', 'PUT',
+    'PATCH', 'DELETE'].join(',');
+
 /**
  * Hock class
  *
@@ -17,6 +25,7 @@ var http = require('http'),
 var Hock = module.exports = function (options) {
   options = options || {};
   this._throwOnUnmatched = (typeof options.throwOnUnmatched === 'boolean' ? options.throwOnUnmatched : true);
+  this._enableCors = (typeof options.enableCors === 'boolean' ? options.throwOnUnmatched : true);
   this._assertions = [];
   this.handler = Hock.prototype.handler.bind(this);
 };
@@ -352,6 +361,19 @@ Hock.prototype.handler = function (req, res) {
 
   req.on('end', function () {
 
+    if (self._enableCors) {
+      var allowHeaders = req.headers['access-control-request-headers'] || ALL_HEADERS;
+      var allowMethods = req.headers['access-control-request-method'] || ALL_METHODS;
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Headers', allowHeaders);
+      res.setHeader('Access-Control-Allow-Methods', allowMethods);
+
+      if (req.method === 'OPTIONS' ) {
+        res.writeHead(200);
+        res.end();
+        return;
+      }
+    }
     for (var i = 0; i < self._assertions.length; i++) {
       if (self._assertions[i].isMatch(req)) {
         matchIndex = i;
@@ -388,6 +410,8 @@ Hock.prototype.handler = function (req, res) {
  * @param {Number}      [options.port]  port number for your Hock server
  * @param {boolean}     [options.throwOnUnmatched]  Tell Hock to throw if
  *    receiving a request without a match (Default=true)
+ * @param {boolean}     [options.enableCors] Allow Cross-origin resource
+ *    sharing (Default=true)
  *
  * @returns {Hock}
  */

--- a/lib/hock.js
+++ b/lib/hock.js
@@ -394,7 +394,7 @@ Hock.prototype.handler = function (req, res) {
       res.end('No Matching Response!\n');
     }
     else {
-      if (self._assertions[matchIndex].sendResponse(res)) {
+      if (self._assertions[matchIndex].sendResponse(req, res)) {
         self._assertions.splice(matchIndex, 1)[0];
       }
     }

--- a/lib/hock.js
+++ b/lib/hock.js
@@ -402,6 +402,19 @@ Hock.prototype.handler = function (req, res) {
 };
 
 /**
+ * Hock.clearRoutes
+ *
+ * @description Clear the assertion queue
+ *
+ * @returns {Hock}
+ */
+Hock.prototype.clearRoutes = function () {
+  var self = this;
+  self._assertions = [];
+  return self;
+}
+
+/**
  * exports.createHock
  *
  * @description static method for creating your hock server

--- a/lib/hock.js
+++ b/lib/hock.js
@@ -73,7 +73,7 @@ Hock.prototype.hasRoute = function (method, url, body, headers) {
   var found = this._assertions.filter(function(request) {
     return request.method === method
           && request.url === url
-          && request.body === body
+          && (!request.body || request.body === body)
           && deepEqual(request.headers, headers);
   })
   return !!found.length;

--- a/lib/request.js
+++ b/lib/request.js
@@ -205,6 +205,11 @@ Request.prototype.isMatch = function(request) {
   }
   else {
     var body = request.body;
+    try {
+      body = JSON.stringify(JSON.parse(body));
+    } catch (error) {
+      // body was not a JavaScript object
+    }
     if (this._requestFilter) {
       body = this._requestFilter(request.body);
     }
@@ -249,7 +254,7 @@ Request.prototype.sendResponse = function(response) {
       // Because we need to respond with this body more than once, if it is a stream,
       // we make a buffer copy and use that as the body for future responses.
       var data = [];
-      
+
       readStream.on('readable', function () {
         var chunk;
         while (null !== (chunk = readStream.read())) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -45,6 +45,7 @@ var Request = module.exports = function (parent, options) {
   });
 
   this._defaultReplyHeaders = {};
+  this._onRequest = function() {};
 
   this._parent = parent;
   this._minRequests = 1;
@@ -185,6 +186,19 @@ Request.prototype.any = function() {
 }
 
 /**
+ * Request.onRequest
+ *
+ * @description sets a hook to be called before sending a response
+ *
+ * @param {Function(req)} onRequest Function to be called with the request
+ * @returns {Request}
+ */
+Request.prototype.onRequest = function (onRequest) {
+  this._onRequest = onRequest;
+  return this;
+}
+
+/**
  * Request.isMatch
  *
  * @description identify if the current request matches the provided request
@@ -238,8 +252,10 @@ Request.prototype.isMatch = function(request) {
  *
  * @param {object}    response    The response object from the hock server
  */
-Request.prototype.sendResponse = function(response) {
+Request.prototype.sendResponse = function(request, response) {
   var self = this;
+
+  this._onRequest(request);
 
   this._count++;
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -210,7 +210,7 @@ Request.prototype.isMatch = function(request) {
     }
 
     return this.method === request.method && this.url === request.url &&
-      this.body === body && checkHeaders();
+      (!this.body || this.body === body) && checkHeaders();
 
   }
 

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -281,6 +281,20 @@ describe('Hock HTTP Tests', function() {
       done();
     });
 
+    it('clears all routes', function(done) {
+      hockInstance
+        .get('/url?password=foo')
+        .reply(200, { 'hock': 'ok' })
+        .clearRoutes()
+        .get('/newurl')
+        .reply(200, { 'hock': 'ok'});
+
+      hockInstance.hasRoute('GET', '/url?password=foo').should.equal(false);
+      hockInstance.hasRoute('GET', '/newurl').should.equal(true);
+
+      done();
+    });
+
     after(function(done) {
       httpServer.close(done);
     });


### PR DESCRIPTION
### Enable CORS (Cross-Origin Resource Sharing)
Add CORS Headers to all responses and always accepts HTTP OPTIONS requests in order to work with XHR requests, e.g.: testing an Angular app with Protractor.

### Match routes when Request body is undefined
Resolves issue #30, matching routes regardless the request body content when the route definition didn't specify a body.
Specifying a body on route definition should still match correctly as long as it's specified first.

### Clear defined routes
In order to avoid routes overmatching the number of requests, I have added a `clearRoutes` to the Hock class which clears the defined routes.
