### PR TITLE
Fix for pattern matching JSON where `request.json = true` is used

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -210,8 +210,18 @@ Request.prototype.isMatch = function(request) {
     }
 
     return this.method === request.method && this.url === request.url &&
-      this.body === body && checkHeaders();
+      checkBody(body, this.body) && checkHeaders();
+  }
 
+  function checkBody(requestBody, validBody) {
+    var val;
+    try {
+      val = JSON.parse(requestBody);
+    }
+    catch (err) {
+      val = requestBody;
+    }
+    return validBody === val || requestBody === validBody;
   }
 
   function checkHeaders() {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "devDependencies": {
     "mocha": "^2.1.0",
-    "request": "2.20.x",
+    "request": "2.83.0",
     "should": "^5.0.1",
     "should-http": "0.0.2"
   },

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -57,6 +57,25 @@ describe('Hock HTTP Tests', function() {
       });
     });
 
+    it('should correctly respond to an HTTP POST request using json:true', function (done) {
+      hockInstance
+        .post('/post', { 'hock': 'post' })
+        .reply(201, { 'hock': 'created' });
+
+      request({
+        uri: 'http://localhost:' + PORT + '/post',
+        method: 'POST',
+        json: true,
+        body: '{"hock":"post"}'
+      }, function (err, res, body) {
+        should.not.exist(err);
+        should.exist(res);
+        res.statusCode.should.equal(201);
+        body.should.eql({ 'hock': 'created' });
+        done();
+      });
+    });
+
     it('should correctly respond to an HTTP PUT request', function (done) {
       hockInstance
         .put('/put', { 'hock': 'put' })


### PR DESCRIPTION
This fixes an incompatibility with newer versions of `request`, which has had about sixty releases since the current pinned version, including some major security vulnerability patches. Security is not likely an issue in this repo as a devDependency, however when others using this framework update they will find certain pattern matchers not working.

This happened with `pkgcloud` in the PR at <https://github.com/pkgcloud/pkgcloud/pull/587>, where a work-around with heavily escaped strings can allow the patterns to be matched.

The specific case where patterns are not matching has been added as a unit test. It involves the documented behaviour of using `request` with `json: true` with `body: <JSON string>` rather than `json: <object value>`.