### PR TITLE
 Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
       "email": "ken.perkins@rackspace.com"
     }
   ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "http://github.com/mmalecki/hock.git"


### PR DESCRIPTION
This project includes the license text in the LICENSE file, but it doesn't indicate which license it uses in the package.json metadata, which doesn't play nicely with some tooling.