### PR TITLE
[reply-functions] Add support to use functions in reply functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ You can optionally send a ReadableStream with reply, for example testing with la
     req.reply(statusCode, new RandomStream(10000), responseHeaders);
 ```
 
+You can also provide functions instead of concrete values. These functions will be called with the matching incoming http request, and it useful in cases where the response body or headers need to be constructed based on the incoming request data:
+
+```Javascript
+    // returns the current hockServer instance
+    req.reply(
+        statusCode,
+        function replyWithBody(request) {
+            return body;
+        },
+        function replyWithHeaders(request) {
+            return responseHeaders;
+        }
+    );
+```
+
 ## Multiple matching requests
 
 You can optionally tell hock to match multiple requests for the same route:

--- a/lib/hock.js
+++ b/lib/hock.js
@@ -394,7 +394,7 @@ Hock.prototype.handler = function (req, res) {
       res.end('No Matching Response!\n');
     }
     else {
-      if (self._assertions[matchIndex].sendResponse(res)) {
+      if (self._assertions[matchIndex].sendResponse(req, res)) {
         self._assertions.splice(matchIndex, 1)[0];
       }
       if (self._assertions.length === 0) self.emit('done');

--- a/lib/request.js
+++ b/lib/request.js
@@ -24,10 +24,11 @@ function bodyEqual(a, b) {
   }
 }
 
-function createResponse(response) {
+function createResponse(request, response) {
   var self = this;
 
-  var headers = this.response.headers || this._defaultReplyHeaders;
+  var headers = typeof this.response.headers === 'function' ? this.response.headers(request) : this.response.headers || this._defaultReplyHeaders;
+  this.response.body = typeof this.response.body === 'function' ? this.response.body(request) : this.response.body;
 
   response.writeHead(this.response.statusCode, headers);
 
@@ -305,19 +306,20 @@ Request.prototype.isMatch = function(request) {
  *
  * @description send the response to the provided Hock response. Applies a delay if it was set
  *
+ * @param {object}    request     The request object from the hock server
  * @param {object}    response    The response object from the hock server
  */
-Request.prototype.sendResponse = function(response) {
+Request.prototype.sendResponse = function(request, response) {
   var self = this;
   this._count++;
 
   if (this._delay > 0) {
     setTimeout(function() {
-        createResponse.call(self, response);
+        createResponse.call(self, request, response);
     }, this._delay);
   }
   else {
-    createResponse.call(this, response);
+    createResponse.call(this, request, response);
   }
 
   return this.shouldPrune();


### PR DESCRIPTION
Some times it is useful to construct responses (body and headers) based on the incoming http request information. This pull request add support for it by allowing to specify functions on both arguments to the `.reply()` function.

I tried to add test cases for both scenarios, but please let me know if additional tests are required.

Thanks for the amazing library!